### PR TITLE
Update ChatGPTClient.js - fix roles in messages for chat-types models

### DIFF
--- a/src/ChatGPTClient.js
+++ b/src/ChatGPTClient.js
@@ -330,7 +330,7 @@ ${botMessage.message}
         const userMessage = {
             id: crypto.randomUUID(),
             parentMessageId,
-            role: 'User',
+            role: 'user',
             message,
         };
         conversation.messages.push(userMessage);
@@ -401,7 +401,7 @@ ${botMessage.message}
         const replyMessage = {
             id: crypto.randomUUID(),
             parentMessageId: userMessage.id,
-            role: 'ChatGPT',
+            role: 'assistant',
             message: reply,
         };
         conversation.messages.push(replyMessage);
@@ -455,7 +455,7 @@ ${botMessage.message}
         };
 
         const messagePayload = {
-            role: 'system',
+            role: 'user',
             content: promptSuffix,
         };
 


### PR DESCRIPTION
Change role for being able to handle OpenAI-like wrappers to other models (e.g. : Llama, Mistral AI, ...). For whatever reason if there is no  message in the thread with user role, those models go mad... So these system/assistant/user roles seems to comply with openAI playground documentation.